### PR TITLE
add Swap download and upload display order feature

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -9,6 +9,9 @@
         <entry name="showSeparately" type="Bool">
             <default>true</default>
         </entry>
+        <entry name="swapDownUp" type="Bool">
+            <default>false</default>
+        </entry>
         <entry name="showIcons" type="Bool">
             <default>true</default>
         </entry>

--- a/package/contents/ui/CompactRepresentation.qml
+++ b/package/contents/ui/CompactRepresentation.qml
@@ -179,8 +179,8 @@ Item {
         width: showSeparately ? iconTextMetrics.advanceWidth / iconTextMetrics.height * height * fontSizeScale : iconTextMetrics.advanceWidth / iconTextMetrics.height * height * fontSizeScale * 2
 
         verticalAlignment: Text.AlignVCenter
-        anchors.left: offsetItem.right
-        y: 0
+        anchors.left: (singleLine && swapDownUp) ? (showUnits ? upUnitText.right : upText.right) : offsetItem.right
+        y: swapDownUp ? (singleLine ? 0 : parent.height / 2) : 0
         font.pixelSize: height * fontHeightRatio * fontSizeScale
 
         text: showSeparately ? '↓' : '↓↑'
@@ -197,9 +197,9 @@ Item {
 
         horizontalAlignment: Text.AlignRight
         verticalAlignment: Text.AlignVCenter
-        anchors.left: showIcons ? downIcon.right : offsetItem.right
+        anchors.left: showIcons ? downIcon.right : ( (singleLine && swapDownUp) ? (showUnits ? upUnitText.right : upText.right) : offsetItem.right )
         anchors.leftMargin: showIcons ? font.pixelSize * marginFactor : 0
-        y: 0
+        y: swapDownUp ? (singleLine ? 0 : parent.height / 2) : 0
         font.pixelSize: height * fontHeightRatio * fontSizeScale
 
         text: speedText(showSeparately ? downSpeed : downSpeed + upSpeed)
@@ -216,7 +216,7 @@ Item {
         verticalAlignment: Text.AlignVCenter
         anchors.left: downText.right
         anchors.leftMargin: font.pixelSize * marginFactor
-        y: 0
+        y: swapDownUp ? (singleLine ? 0 : parent.height / 2) : 0
         font.pixelSize: height * fontHeightRatio * fontSizeScale
 
         text: speedUnit(showSeparately ? downSpeed : downSpeed + upSpeed)
@@ -232,9 +232,9 @@ Item {
         width: iconTextMetrics.advanceWidth / iconTextMetrics.height * height * fontSizeScale
 
         verticalAlignment: Text.AlignVCenter
-        anchors.left: (singleLine && showUnits) ? downUnitText.right : (singleLine ? downText.right : offsetItem.right)
+        anchors.left: (singleLine && !swapDownUp) ? (showUnits ? downUnitText.right : downText.right) : offsetItem.right
         anchors.leftMargin: singleLine ? font.pixelSize * marginFactor : 0
-        y: singleLine ? 0 : parent.height / 2
+        y: swapDownUp ? 0 : (singleLine ? 0 : parent.height / 2)
         font.pixelSize: height * fontHeightRatio * fontSizeScale
 
         text: '↑'
@@ -251,9 +251,9 @@ Item {
 
         horizontalAlignment: Text.AlignRight
         verticalAlignment: Text.AlignVCenter
-        anchors.left: showIcons ? upIcon.right : ((singleLine && showUnits) ? downUnitText.right : (singleLine ? downText.right : offsetItem.right))
+        anchors.left: showIcons ? upIcon.right : ((singleLine && !swapDownUp) ? (showUnits ? downUnitText.right : downText.right) : offsetItem.right)
         anchors.leftMargin: (showIcons || singleLine) ? font.pixelSize * marginFactor : 0
-        y: singleLine ? 0 : parent.height / 2
+        y: swapDownUp ? 0 : (singleLine ? 0 : parent.height / 2)
         font.pixelSize: height * fontHeightRatio * fontSizeScale
 
         text: speedText(upSpeed)
@@ -271,7 +271,7 @@ Item {
         verticalAlignment: Text.AlignVCenter
         anchors.left: upText.right
         anchors.leftMargin: font.pixelSize * marginFactor
-        y: singleLine ? 0 : parent.height / 2
+        y: swapDownUp ? 0 : (singleLine ? 0 : parent.height / 2)
         font.pixelSize: height * fontHeightRatio * fontSizeScale
 
         text: speedUnit(upSpeed)

--- a/package/contents/ui/config/ConfigGeneral.qml
+++ b/package/contents/ui/config/ConfigGeneral.qml
@@ -20,6 +20,7 @@ import QtQuick.Layouts 1.1
 
 Item {
     property alias cfg_showSeparately: showSeparately.checked
+    property alias cfg_swapDownUp: swapDownUp.checked
     property alias cfg_showIcons: showIcons.checked
     property alias cfg_showUnits: showUnits.checked
     property string cfg_speedUnits: 'bytes'
@@ -87,6 +88,12 @@ Item {
         CheckBox {
             id: showSeparately
             text: i18n('Show download and upload speed separately')
+            Layout.columnSpan: 2
+        }
+
+        CheckBox {
+            id: swapDownUp
+            text: i18n('Swap download and upload display order')
             Layout.columnSpan: 2
         }
 

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -20,6 +20,7 @@ import org.kde.plasma.core 2.0 as PlasmaCore
 
 Item {
     property bool showSeparately: plasmoid.configuration.showSeparately
+    property bool swapDownUp: plasmoid.configuration.swapDownUp
     property bool showIcons: plasmoid.configuration.showIcons
     property bool showUnits: plasmoid.configuration.showUnits
     property string speedUnits: plasmoid.configuration.speedUnits


### PR DESCRIPTION
add an "Swap download and upload display order" option in General Settings, which allow user swap the display order of the upload speed and download speed

![screenshot_20180704_202111](https://user-images.githubusercontent.com/6263652/42276832-cc507b9a-7fc7-11e8-8add-6031573f262e.png)
![screenshot_20180704_202227](https://user-images.githubusercontent.com/6263652/42276871-f9a80004-7fc7-11e8-8121-8d260fed4c42.png)
