### PR TITLE
Update shebang

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 mkdir --parents --verbose ~/.local/share/plasma/plasmoids/org.kde.netspeedWidget
 cp --recursive --update --verbose ./package/* $_


### PR DESCRIPTION
Hi, I updated the Shebang for the install script to `#!/usr/bin/env bash` because it is more compatible and portable. For example, on the NixOS I use, there is no `/bin/env` file path, so I had to manually modify it to execute the installation. That's my reason, I hope you can accept it.

By the way, version 2.0 can display network speed and also show a list of network interfaces on my end. It works perfectly.