### PR TITLE
Fix ToolTipArea

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -45,9 +45,9 @@ PlasmoidItem {
     property var transferData: {}
     property var speedData: {}
 
-    fullRepresentation: CompactRepresentation {} // HACK: Remove whenever preferredRepresentation stops being ignored
-    compactRepresentation: CompactRepresentation {}
-    preferredRepresentation: compactRepresentation
+    // For some reason, ToolTipAreas only work with fullRepresentation now
+    fullRepresentation: CompactRepresentation {}
+    preferredRepresentation: fullRepresentation
 
     Plasma5Support.DataSource {
         id: dataSource


### PR DESCRIPTION
Works around odd Plasma 6 behavior that causes ToolTipAreas to not work properly when preferredRepresentation is set to compactRepresentation
